### PR TITLE
Feature/move to ffi napi

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var FFI = require('ffi'),
+var FFI = require('ffi-napi'),
     ArrayType = require('ref-array'),
     Struct = require('ref-struct'),
     ref = require('ref');

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "url": "https://github.com/NitroPye/node-pdflib/issues"
   },
   "dependencies": {
-    "ffi": "^2.2.0",
-    "libclang": "0.0.11",
+    "ffi-napi": "^2.4.5",
     "ref": "^1.0.2",
     "ref-array": "^1.1.1",
     "ref-struct": "^1.0.1"


### PR DESCRIPTION
ffi is having a lot of issues working with newer versions of node (ie https://github.com/node-ffi/node-ffi/issues/509, https://github.com/node-ffi/node-ffi/issues/465), switching to ffi-napi solves it and is still backwards compatible